### PR TITLE
Fix unseal key handling

### DIFF
--- a/venv
+++ b/venv
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 export VAULT_TOKEN=$(cat ~/data/vault-init.json | jq -r .root_token)
-export VAULT_SEAL_KEY=$(cat ~/data/vault-init.json | jq -r .unseal_keys_b64[])
+# Use only the first unseal key when exporting VAULT_SEAL_KEY
+# The previous command expanded all unseal keys which caused
+# `vault operator unseal` to receive multiple arguments.
+export VAULT_SEAL_KEY=$(jq -r '.unseal_keys_b64[0]' ~/data/vault-init.json)
 export VAULT_ADDR=https://vault.mac.example.com:8200
 export VAULT_SKIP_VERIFY=true
 

--- a/vup
+++ b/vup
@@ -5,4 +5,4 @@
 cd ~/data && \
   /opt/homebrew/bin/docker-compose up -d && \
   sleep 2 && \
-  vault operator unseal $VAULT_SEAL_KEY
+  vault operator unseal "$VAULT_SEAL_KEY"


### PR DESCRIPTION
## Summary
- only use the first unseal key when exporting `VAULT_SEAL_KEY`
- quote the variable in `vup`

## Testing
- `bash -n venv vup vdown`

------
https://chatgpt.com/codex/tasks/task_e_68431632fac8832ba3a5f1e90af7e357