### PR TITLE
Add setup script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Local Vault Environment
+
+This repository contains a small Docker Compose setup for running Vault Enterprise
+behind Traefik. It is intended for local testing.
+
+## Prerequisites
+
+* Docker and `docker-compose`
+* `jq`
+* `openssl`
+* A Vault Enterprise license file (copy it to `vault.hclic` after running the
+  setup script)
+
+## Setup
+
+1. Run `./setup.sh` to create required folders and generate self‑signed TLS
+   certificates.
+2. Copy your Vault license to `vault.hclic` in the repository root.
+3. Add the following line to your `/etc/hosts` file so the example domains
+   resolve locally:
+
+   ```
+   127.0.0.1  traefik.mac.example.com vault.mac.example.com mac.example.com
+   ```
+4. Start the environment with `./vup`.
+5. On first run, initialize Vault and save the output:
+
+   ```
+   docker exec -it vault vault operator init -format=json > vault-init.json
+   ```
+
+   Source the generated environment variables with:
+
+   ```
+   . ./venv
+   ```
+
+   Then unseal with `./vup` or `vault operator unseal`.
+
+## Stopping
+
+Use `./vdown` to stop the containers.
+
+## Notes
+
+The generated certificates are self signed and intended for local use only.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+# Prepare directories
+mkdir -p certs traefik vault/audit vault/snapshots vault/plugins
+
+# Check dependencies
+for cmd in docker docker-compose jq openssl; do
+  if ! command -v $cmd >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed" >&2
+    exit 1
+  fi
+done
+
+# Generate self-signed certificate if missing
+if [ ! -f certs/privkey.pem ]; then
+  openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
+    -keyout certs/privkey.pem \
+    -out certs/certificate.pem \
+    -subj "/CN=mac.example.com"
+  cp certs/certificate.pem certs/fullchain.pem
+  cp certs/certificate.pem certs/ca.pem
+fi
+
+# Create traefik tls config
+cat > traefik/tls.toml <<'CONFIG'
+[tls.stores]
+  [tls.stores.default.defaultCertificate]
+    certFile = "/certs/fullchain.pem"
+    keyFile  = "/certs/privkey.pem"
+CONFIG
+
+cat <<'MSG'
+Setup complete. Copy your Vault Enterprise license file to vault.hclic
+and run ./vup to start the environment.
+MSG


### PR DESCRIPTION
## Summary
- create `setup.sh` for preparing certificates and folders
- document setup in new `README.md`

## Testing
- `bash -n setup.sh`
- `./setup.sh` *(fails: docker is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843190081fc832b87cc863127467bd0