### PR TITLE
Improve vup script and default env

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ shown below:
    source venv
    ```
 
-5. The Vault UI will be available at `https://vault.mac.example.com` and the
+5. The Vault UI will be available at `https://127.0.0.1:8200` (or
+   `https://vault.mac.example.com` if you mapped the hostname) and the
    Traefik dashboard at `https://traefik.mac.example.com`.
 
 6. When finished, stop the containers with:

--- a/venv
+++ b/venv
@@ -5,6 +5,7 @@ export VAULT_TOKEN=$(cat ~/data/vault-init.json | jq -r .root_token)
 # The previous command expanded all unseal keys which caused
 # `vault operator unseal` to receive multiple arguments.
 export VAULT_SEAL_KEY=$(jq -r '.unseal_keys_b64[0]' ~/data/vault-init.json)
-export VAULT_ADDR=https://vault.mac.example.com:8200
+# Point to localhost to avoid DNS issues on new machines
+export VAULT_ADDR=https://127.0.0.1:8200
 export VAULT_SKIP_VERIFY=true
 

--- a/vup
+++ b/vup
@@ -1,8 +1,26 @@
 #!/bin/bash
 
-. ~/data/venv
+# Load environment variables if available
+VENV_DIR="$HOME/data/venv"
+if [ -f "$VENV_DIR" ]; then
+  . "$VENV_DIR"
+fi
 
-cd ~/data && \
-  /opt/homebrew/bin/docker-compose up -d && \
-  sleep 2 && \
+# Determine which Compose file to use. Prefer the multi-cluster
+# configuration if present.
+COMPOSE_FILE="$HOME/data/docker-compose.yml"
+if [ ! -f "$COMPOSE_FILE" ]; then
+  COMPOSE_FILE="$HOME/data/docker-compose.yaml"
+fi
+
+# Choose the compose command based on what is installed
+if command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD="docker-compose"
+else
+  COMPOSE_CMD="docker compose"
+fi
+
+cd "$HOME/data" && \
+  $COMPOSE_CMD -f "$COMPOSE_FILE" up -d && \
+  sleep 5 && \
   vault operator unseal "$VAULT_SEAL_KEY"


### PR DESCRIPTION
## Summary
- load `venv` automatically and detect docker compose command
- prefer the multi-cluster compose file
- use localhost for `VAULT_ADDR`
- document updated URL for the Vault UI

## Testing
- `bash -n vup`
- `bash -n venv`
- `bash -n vdown`


------
https://chatgpt.com/codex/tasks/task_e_6843294a5f40832ba11fe20bacc4fa5b