### PR TITLE
Remove path assumption from helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ shown below:
 
 ## Getting started
 
-1. Clone this repository. The helper scripts assume it lives under
-   `~/data`. Either clone it there or modify the scripts accordingly.
+1. Clone this repository anywhere on your filesystem. The helper
+   scripts automatically detect their location, so no special path is
+   required.
    ```bash
-   git clone <repo-url> ~/data
-   cd ~/data
+   git clone <repo-url> <any-path>
+   cd <any-path>
    ```
 
 2. Ensure the `certs/` and `traefik/` directories contain the required files

--- a/vdown
+++ b/vdown
@@ -1,6 +1,21 @@
 #!/bin/bash
 
-. ~/data/venv
+# Determine the repository root based on this script's location
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-cd ~/data && \
-  /opt/homebrew/bin/docker-compose down
+# Load environment variables if available
+[ -f "$SCRIPT_DIR/venv" ] && . "$SCRIPT_DIR/venv"
+
+# Determine which Compose file to use
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
+[ -f "$COMPOSE_FILE" ] || COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yaml"
+
+# Choose the compose command based on what is installed
+if command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD="docker-compose"
+else
+  COMPOSE_CMD="docker compose"
+fi
+
+cd "$SCRIPT_DIR" && \
+  $COMPOSE_CMD -f "$COMPOSE_FILE" down

--- a/venv
+++ b/venv
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-export VAULT_TOKEN=$(cat ~/data/vault-init.json | jq -r .root_token)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export VAULT_TOKEN=$(jq -r .root_token "$SCRIPT_DIR/vault-init.json")
 # Use only the first unseal key when exporting VAULT_SEAL_KEY
 # The previous command expanded all unseal keys which caused
 # `vault operator unseal` to receive multiple arguments.
-export VAULT_SEAL_KEY=$(jq -r '.unseal_keys_b64[0]' ~/data/vault-init.json)
+export VAULT_SEAL_KEY=$(jq -r '.unseal_keys_b64[0]' "$SCRIPT_DIR/vault-init.json")
 # Point to localhost to avoid DNS issues on new machines
 export VAULT_ADDR=https://127.0.0.1:8200
 export VAULT_SKIP_VERIFY=true

--- a/vup
+++ b/vup
@@ -1,16 +1,19 @@
 #!/bin/bash
 
+# Determine the repository root based on this script's location
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Load environment variables if available
-VENV_DIR="$HOME/data/venv"
+VENV_DIR="$SCRIPT_DIR/venv"
 if [ -f "$VENV_DIR" ]; then
   . "$VENV_DIR"
 fi
 
 # Determine which Compose file to use. Prefer the multi-cluster
 # configuration if present.
-COMPOSE_FILE="$HOME/data/docker-compose.yml"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
 if [ ! -f "$COMPOSE_FILE" ]; then
-  COMPOSE_FILE="$HOME/data/docker-compose.yaml"
+  COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yaml"
 fi
 
 # Choose the compose command based on what is installed
@@ -20,7 +23,7 @@ else
   COMPOSE_CMD="docker compose"
 fi
 
-cd "$HOME/data" && \
+cd "$SCRIPT_DIR" && \
   $COMPOSE_CMD -f "$COMPOSE_FILE" up -d && \
   sleep 5 && \
   vault operator unseal "$VAULT_SEAL_KEY"


### PR DESCRIPTION
## Summary
- update README instructions to drop `~/data` requirement
- make `vup` load compose file based on script path
- make `vdown` detect repo directory and run Docker Compose from there
- update `venv` to read `vault-init.json` from script path

## Testing
- `bash -n vup vdown venv`
- `./vup` *(fails: jq/dcoker missing)*
- `./vdown` *(fails: jq/docker missing)*

------
https://chatgpt.com/codex/tasks/task_e_68432b9e9a8c832bb61e4c2ac3d80c4b