### PR TITLE
Fix startup scripts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"
     ports:
-      - "80:80"
+      - "8200:80"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 

--- a/venv
+++ b/venv
@@ -8,6 +8,6 @@ export VAULT_TOKEN=$(jq -r .root_token "$SCRIPT_DIR/vault-init.json")
 # `vault operator unseal` to receive multiple arguments.
 export VAULT_SEAL_KEY=$(jq -r '.unseal_keys_b64[0]' "$SCRIPT_DIR/vault-init.json")
 # Point to localhost to avoid DNS issues on new machines
-export VAULT_ADDR=https://127.0.0.1:8200
+export VAULT_ADDR=http://127.0.0.1:8200
 export VAULT_SKIP_VERIFY=true
 

--- a/vup
+++ b/vup
@@ -25,5 +25,8 @@ fi
 
 cd "$SCRIPT_DIR" && \
   $COMPOSE_CMD -f "$COMPOSE_FILE" up -d && \
-  sleep 5 && \
+  echo "Waiting for Vault to become available..." && \
+  until curl -s "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do
+    sleep 2
+  done && \
   vault operator unseal "$VAULT_SEAL_KEY"


### PR DESCRIPTION
## Summary
- map host port 8200 to Traefik
- update environment to use HTTP
- wait for Vault availability before unseal

## Testing
- `bash -n vup`
- `bash -n vdown`
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68432fd7bbc0832b9f7b120e6bf40fe5