### PR TITLE
Fix Vault unseal 404 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ shown below:
    source venv
    ```
 
-5. The Vault UI will be available at `https://127.0.0.1:8200` (or
-   `https://vault.mac.example.com` if you mapped the hostname) and the
-   Traefik dashboard at `https://traefik.mac.example.com`.
+5. The Vault UI will be available at `http://127.0.0.1:8200` (or
+   `http://vault.mac.example.com` if you mapped the hostname) and the
+   Traefik dashboard at `http://traefik.mac.example.com`.
 
 6. When finished, stop the containers with:
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
         api_addr = "http://c1-node1:8200"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.cluster1.rule=Host(`cluster1.local`)"
+      - "traefik.http.routers.cluster1.rule=Host(`cluster1.local`) || Host(`127.0.0.1`)"
       - "traefik.http.services.cluster1.loadbalancer.server.port=8200"
 
   c1-node2:
@@ -63,7 +63,7 @@ services:
         api_addr = "http://c1-node2:8200"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.cluster1.rule=Host(`cluster1.local`)"
+      - "traefik.http.routers.cluster1.rule=Host(`cluster1.local`) || Host(`127.0.0.1`)"
       - "traefik.http.services.cluster1.loadbalancer.server.port=8200"
 
   c1-node3:
@@ -91,7 +91,7 @@ services:
         api_addr = "http://c1-node3:8200"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.cluster1.rule=Host(`cluster1.local`)"
+      - "traefik.http.routers.cluster1.rule=Host(`cluster1.local`) || Host(`127.0.0.1`)"
       - "traefik.http.services.cluster1.loadbalancer.server.port=8200"
 
   # Cluster 2


### PR DESCRIPTION
## Summary
- route cluster1 through 127.0.0.1 so vup works without custom hostnames
- clarify that Vault and Traefik run over HTTP on port 8200

## Testing
- `bash -n vup`
- `bash -n vdown`
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_684335d4dc0c832b9389980ab2375cb7